### PR TITLE
Make the mod a 'library' in modmenu

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,7 +7,11 @@
         "client": [ "de.guntram.mcmod.fabrictools.DummyMain" ]
     },
     "custom": {
-        "modmenu:api": true
+        "modmenu": {
+            "badges": [
+               "library"
+            ]
+        }
     },
     "mixins": [
       	"mixins.de-guntram-mcmod-fabrictools.json"


### PR DESCRIPTION
Make the mod a 'library' in modmenu

fixes issue #1

Note: there is no 1.18 branch on the repo, so I PR'd against 1.17 as a
fallback.

Signed-off-by: MeeniMc <68366846+MeeniMc@users.noreply.github.com>